### PR TITLE
Fixed wildcard matching for admin check causing Reader role false positive

### DIFF
--- a/AzurePEAS.py
+++ b/AzurePEAS.py
@@ -810,10 +810,16 @@ class AzurePEASS(CloudPEASS):
         """
         perms_str = [str(p).lower() for p in permissions]
         
-        # Check for wildcard permissions that indicate full access
-        admin_perms = ["*" ,"*/*", "*/action", "*/write", "*/create", "*/update"]
-        if any(admin in p for admin in admin_perms for p in perms_str):
+        # Exact wildcards = full admin (Owner, Contributor roles)
+        if any(p == "*" or p == "*/*" for p in perms_str):
             return True
+        
+        # Wildcard action patterns = admin (must start with */ to be a wildcard)
+        # These indicate broad administrative access across ALL resources
+        admin_suffixes = ["/action", "/write", "/create", "/update"]
+        for perm in perms_str:
+            if perm.startswith("*/") and any(perm.endswith(suffix) for suffix in admin_suffixes):
+                return True
         
         return False
     


### PR DESCRIPTION
The check in `_is_admin_azure` is matching on `*` causing `*/read` to flag as admin level access, which would skip further enumeration.
Updated the function to exact match on `*` and `*/*` and added wildcard detection for `*/action, */write, */create, */update`.

Disregard if this is intended!

**Before change**
<img width="1372" height="828" alt="image" src="https://github.com/user-attachments/assets/964f41fd-d1d1-4e6e-9b28-9831318ae73b" />

**After change**
<img width="1378" height="890" alt="image" src="https://github.com/user-attachments/assets/b8760dfd-d33c-4ece-9388-14b1f4b5bd21" />

