### PR TITLE
fixed risk rule matching issues and updated risk rule url

### DIFF
--- a/src/CloudPEASS/cloudpeass.py
+++ b/src/CloudPEASS/cloudpeass.py
@@ -377,16 +377,13 @@ class CloudPEASS:
             print(f"{Fore.WHITE}Resources: {Fore.CYAN}{f'{Fore.WHITE} , {Fore.CYAN}'.join(result['resources'])}")
             
             # Organize permissions by category
-            wildcards_perms = []
             critical_perms = []
             high_perms = []
             medium_perms = []
             low_perms = []
             
             for perm in perms:
-                if '*' in perm:
-                    wildcards_perms.append(perm)
-                elif perm in critical:
+                if perm in critical:
                     critical_perms.append(perm)
                 elif perm in high:
                     high_perms.append(perm)
@@ -398,7 +395,7 @@ class CloudPEASS:
             # Build permissions message with sorted categories
             perms_msg = f"{Fore.WHITE}Permissions: "
             
-            for perm in wildcards_perms + critical_perms:
+            for perm in critical_perms:
                 perms_msg += f"{Fore.RED}{Back.YELLOW}{perm}{Style.RESET_ALL}, "
             
             for perm in high_perms:

--- a/src/CloudPEASS/permission_risk_classifier.py
+++ b/src/CloudPEASS/permission_risk_classifier.py
@@ -481,6 +481,16 @@ def _azure_contains_boundary_keywords(lower: str, rules: AzureRules) -> bool:
     return any(k in lower for k in rules.boundary_keywords)
 
 
+def _highest_risk(levels: Iterable[Optional[str]]) -> Optional[str]:
+    best = None
+    for level in levels:
+        if level is None:
+            continue
+        if best is None or RISK_ORDER[level] > RISK_ORDER[best]:
+            best = level
+    return best
+
+
 def azure_override_level(permission: str, rules: AzureRules) -> Optional[str]:
     permission = permission.strip()
     if not permission:
@@ -550,32 +560,48 @@ def azure_override_level(permission: str, rules: AzureRules) -> Optional[str]:
     return None
 
 
-def azure_regex_classify(permission: str, rules: AzureRules) -> Optional[str]:
+def _azure_wildcard_level(permission: str, rules: AzureRules) -> Optional[str]:
     permission = permission.strip()
     if not permission:
         return None
-
-    forced = azure_override_level(permission, rules)
-    if forced is not None:
-        return forced
-
-    lower = permission.lower()
 
     # True full-admin wildcards remain critical.
     if permission == "*" or permission == "*/*":
         return "critical"
 
-    # Root-namespace wildcard under Microsoft.Authorization/ grants RBAC breadth.
-    if lower == "microsoft.authorization/*":
+    if not permission.endswith("/*"):
+        return None
+
+    base = permission[:-2].strip("/")
+    lower_base = base.lower()
+
+    # Provider-root wildcards grant every operation under that provider namespace.
+    # That is broad enough to include unknown privileged child actions, so keep it
+    # critical instead of pretending it is only a provider-level write.
+    if lower_base.count("/") == 0:
         return "critical"
 
-    # Other namespace-scoped wildcards (e.g. "Microsoft.HybridCompute/licenses/*") are not
-    # automatically critical. Classify them by the underlying namespace: strip the trailing
-    # "/*" and treat the result as a write/action (the most permissive standard verb), so
-    # the existing namespace-aware logic below assigns risk based on the resource type.
-    if permission.endswith("/*"):
-        permission = permission[:-2] + "/write"
-        lower = permission.lower()
+    if lower_base.startswith("microsoft.authorization/"):
+        if any(k in lower_base for k in ("roleassignments", "roledefinitions", "elevateaccess")):
+            return "critical"
+
+    if lower_base.startswith("microsoft.managedidentity/"):
+        if any(k in lower_base for k in ("userassignedidentities", "federatedidentitycredentials")):
+            return "critical"
+
+    if lower_base == "microsoft.storage/storageaccounts":
+        return "critical"
+
+    likely_child_permissions = [f"{base}/{verb}" for verb in ("read", "write", "delete", "action")]
+    return _highest_risk(_azure_classify_non_wildcard(child, rules) for child in likely_child_permissions)
+
+
+def _azure_classify_non_wildcard(permission: str, rules: AzureRules) -> Optional[str]:
+    forced = azure_override_level(permission, rules)
+    if forced is not None:
+        return forced
+
+    lower = permission.lower()
 
     last = _azure_last_segment(permission)
     is_read = last == "read"
@@ -628,6 +654,18 @@ def azure_regex_classify(permission: str, rules: AzureRules) -> Optional[str]:
         return "medium"
 
     return None
+
+
+def azure_regex_classify(permission: str, rules: AzureRules) -> Optional[str]:
+    permission = permission.strip()
+    if not permission:
+        return None
+
+    wildcard_level = _azure_wildcard_level(permission, rules)
+    if wildcard_level is not None:
+        return wildcard_level
+
+    return _azure_classify_non_wildcard(permission, rules)
 
 
 def classify_permission(provider: str, permission: str, *, unknown_default: str = "high") -> str:

--- a/src/CloudPEASS/permission_risk_classifier.py
+++ b/src/CloudPEASS/permission_risk_classifier.py
@@ -1,10 +1,10 @@
 """
 Permission risk classifier for AWS, Azure, and GCP.
 Adapted from Blue-PEASS for CloudPEASS integration.
-Downloads risk_rules YAML files from Blue-PEASS repo at runtime.
+Downloads risk_rules YAML files from Blue-CloudPEASS repo at runtime.
 
-Note: The Blue-PEASS repository must be publicly accessible at:
-https://github.com/carlospolop/Blue-PEASS
+Note: The Blue-CloudPEASS repository must be publicly accessible at:
+https://github.com/peass-ng/Blue-CloudPEASS
 """
 
 from __future__ import annotations
@@ -23,9 +23,9 @@ import yaml
 RISK_ORDER = {"low": 0, "medium": 1, "high": 2, "critical": 3}
 RISK_LEVELS = ("low", "medium", "high", "critical")
 
-# Blue-PEASS GitHub repository base URL
-# Note: Update this to match your Blue-PEASS repository name and branch
-BLUEPEASS_RISK_RULES_BASE_URL = "https://raw.githubusercontent.com/carlospolop/Blue-PEASS/main/risk_rules"
+# Blue-CloudPEASS GitHub repository base URL
+# Note: Update this to match your Blue-CloudPEASS repository name and branch
+BLUEPEASS_RISK_RULES_BASE_URL = "https://raw.githubusercontent.com/peass-ng/Blue-CloudPEASS/refs/heads/main/risk_rules"
 RISK_RULES_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60  # 7 days
 
 
@@ -515,10 +515,10 @@ def azure_override_level(permission: str, rules: AzureRules) -> Optional[str]:
         if any(lower.startswith(p) for p in rules.insights_medium_prefixes_write_or_action) and lower.endswith(("/write", "/action")):
             return "medium"
 
-        if lower.startswith(rules.insights_activitylogalerts_prefix) and (lower.endswith("/write") or lower.endswith("/activated/action")):
+        if rules.insights_activitylogalerts_prefix and lower.startswith(rules.insights_activitylogalerts_prefix) and (lower.endswith("/write") or lower.endswith("/activated/action")):
             return "medium"
 
-        if lower.startswith(rules.insights_alertrules_prefix) and lower.endswith(
+        if rules.insights_alertrules_prefix and lower.startswith(rules.insights_alertrules_prefix) and lower.endswith(
             ("/write", "/activated/action", "/resolved/action", "/throttled/action")
         ):
             return "medium"
@@ -530,17 +530,17 @@ def azure_override_level(permission: str, rules: AzureRules) -> Optional[str]:
                 return None
             return "medium"
 
-    if lower.startswith(rules.resourcehealth_events_action_prefix) and lower.endswith("/action"):
+    if rules.resourcehealth_events_action_prefix and lower.startswith(rules.resourcehealth_events_action_prefix) and lower.endswith("/action"):
         return "medium"
 
-    if lower.startswith(rules.billing_provider_prefix):
+    if rules.billing_provider_prefix and lower.startswith(rules.billing_provider_prefix):
         if any(k in lower for k in rules.billing_exclude_keywords):
             return None
         last = _azure_last_segment(permission)
         if last in ("write", "action"):
             return "medium"
 
-    if lower.startswith(rules.appinsights_component_prefix):
+    if rules.appinsights_component_prefix and lower.startswith(rules.appinsights_component_prefix):
         if any(k in lower for k in rules.appinsights_exclude_keywords):
             return None
         last = _azure_last_segment(permission)
@@ -561,8 +561,21 @@ def azure_regex_classify(permission: str, rules: AzureRules) -> Optional[str]:
 
     lower = permission.lower()
 
-    if permission == "*" or permission.endswith("/*") or permission == "*/*":
+    # True full-admin wildcards remain critical.
+    if permission == "*" or permission == "*/*":
         return "critical"
+
+    # Root-namespace wildcard under Microsoft.Authorization/ grants RBAC breadth.
+    if lower == "microsoft.authorization/*":
+        return "critical"
+
+    # Other namespace-scoped wildcards (e.g. "Microsoft.HybridCompute/licenses/*") are not
+    # automatically critical. Classify them by the underlying namespace: strip the trailing
+    # "/*" and treat the result as a write/action (the most permissive standard verb), so
+    # the existing namespace-aware logic below assigns risk based on the resource type.
+    if permission.endswith("/*"):
+        permission = permission[:-2] + "/write"
+        lower = permission.lower()
 
     last = _azure_last_segment(permission)
     is_read = last == "read"

--- a/tests/test_permission_risk_classifier.py
+++ b/tests/test_permission_risk_classifier.py
@@ -1,0 +1,126 @@
+import re
+import unittest
+from typing import Optional
+
+from CloudPEASS.permission_risk_classifier import AzureRules, azure_regex_classify
+
+
+def azure_rules() -> AzureRules:
+    dangerous_write_keywords = (
+        "microsoft.authorization/",
+        "roleassignments",
+        "roledefinitions",
+        "elevateaccess",
+        "authorization",
+        "managedidentity",
+        "microsoft.keyvault/",
+        "/secrets/",
+        "/keys/",
+        "/certificates/",
+        "policy",
+        "privatelink",
+        "privateendpoint",
+    )
+    return AzureRules(
+        credential_action_re=re.compile(
+            r"/(listsecrets|listkeys|listcredentials|listcredential|listadminkeys|listadminkey|getsecret|getsecrets|getkeys|getkey|getadminkeys|getadminkey|getauthtoken|getaccesstoken|regeneratekey|regeneratekeys|regeneratepassword|generatecredentials|generatecredential|generatekey|generatetoken|listpasswords|listpassword)/action$",
+            re.IGNORECASE,
+        ),
+        storage_insights_child_re=re.compile(
+            r"^microsoft\.storage/storageaccounts/(blobservices|fileservices|queueservices|tableservices)/providers/microsoft\.insights/(diagnosticsettings|logdefinitions|metricdefinitions)/read$",
+            re.IGNORECASE,
+        ),
+        register_like_action_re=re.compile(r"/(register|unregister|checknameavailability)/action$", re.IGNORECASE),
+        provider_diagnostic_settings_write_re=re.compile(
+            r"/providers/microsoft\.insights/diagnosticsettings/write$",
+            re.IGNORECASE,
+        ),
+        boundary_keywords=(
+            "networksecurityperimeter",
+            "privatelink",
+            "privateendpoint",
+            "scopedprivatelink",
+            "privateendpointconnection",
+        ),
+        cost_mgmt_exact_medium={
+            "microsoft.costmanagement/query/action",
+            "microsoft.costmanagement/forecast/action",
+            "microsoft.costmanagement/calculatecost/action",
+            "microsoft.costmanagement/fetchprices/action",
+            "microsoft.advisor/generaterecommendations/action",
+            "microsoft.consumption/budgets/write",
+        },
+        insights_exclude_keywords=("/apikeys/", "apikey", "secret", "token", "credential", "key"),
+        insights_medium_prefixes_write=(
+            "microsoft.insights/diagnosticsettings/",
+            "microsoft.insights/extendeddiagnosticsettings/",
+            "microsoft.insights/actiongroups/",
+            "microsoft.insights/metricalerts/",
+            "microsoft.insights/logprofiles/",
+            "microsoft.insights/workbooks/",
+            "microsoft.insights/workbooktemplates/",
+            "microsoft.insights/webtests/",
+        ),
+        insights_medium_prefixes_write_or_action=(
+            "microsoft.insights/autoscalesettings/",
+            "microsoft.insights/metrics/",
+            "microsoft.insights/scheduledqueryrules/",
+        ),
+        insights_activitylogalerts_prefix="microsoft.insights/activitylogalerts/",
+        insights_alertrules_prefix="microsoft.insights/alertrules/",
+        medium_write_action_provider_prefixes=(
+            "microsoft.support/",
+            "microsoft.advisor/",
+            "microsoft.costmanagement/",
+        ),
+        resourcehealth_events_action_prefix="microsoft.resourcehealth/events/",
+        billing_provider_prefix="microsoft.billing/",
+        billing_exclude_keywords=(
+            "billingroleassignments",
+            "createbillingroleassignment",
+            "resolvebillingroleassignments",
+            "/elevate/action",
+            "roleassignments",
+            "roledefinitions",
+            "authorization",
+        ),
+        appinsights_component_prefix="microsoft.insights/components/",
+        appinsights_exclude_keywords=("/apikeys/", "apikey", "exportconfiguration", "linkedstorageaccounts"),
+        dangerous_write_keywords=dangerous_write_keywords,
+        dangerous_write_keywords_lower=tuple(k.lower() for k in dangerous_write_keywords),
+    )
+
+
+class AzureWildcardClassificationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rules = azure_rules()
+
+    def classify(self, permission: str) -> Optional[str]:
+        return azure_regex_classify(permission, self.rules)
+
+    def test_global_and_provider_root_wildcards_stay_critical(self) -> None:
+        self.assertEqual(self.classify("*"), "critical")
+        self.assertEqual(self.classify("*/*"), "critical")
+        self.assertEqual(self.classify("Microsoft.Authorization/*"), "critical")
+        self.assertEqual(self.classify("Microsoft.KeyVault/*"), "critical")
+        self.assertEqual(self.classify("Microsoft.Storage/*"), "critical")
+
+    def test_resource_type_wildcards_are_not_automatically_critical(self) -> None:
+        self.assertEqual(self.classify("Microsoft.HybridCompute/licenses/*"), "medium")
+        self.assertEqual(self.classify("Microsoft.Insights/actionGroups/*"), "medium")
+        self.assertEqual(self.classify("Microsoft.Compute/virtualMachines/*"), "medium")
+
+    def test_wildcards_keep_maximum_risk_from_likely_child_verbs(self) -> None:
+        self.assertEqual(self.classify("Microsoft.KeyVault/vaults/secrets/read"), "critical")
+        self.assertEqual(self.classify("Microsoft.KeyVault/vaults/secrets/write"), "high")
+        self.assertEqual(self.classify("Microsoft.KeyVault/vaults/secrets/*"), "critical")
+
+    def test_known_privilege_escalation_wildcards_stay_critical(self) -> None:
+        self.assertEqual(self.classify("Microsoft.Authorization/roleAssignments/*"), "critical")
+        self.assertEqual(self.classify("Microsoft.Authorization/roleDefinitions/*"), "critical")
+        self.assertEqual(self.classify("Microsoft.ManagedIdentity/userAssignedIdentities/*"), "critical")
+        self.assertEqual(self.classify("Microsoft.Storage/storageAccounts/*"), "critical")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Blue-CloudPeass risk definition file was 404ing, updated. 
Any permission with a wildcard in it at all was being flagged as a critical, fixed parsing to match risk rules. 